### PR TITLE
Saltern job pool hotfix.

### DIFF
--- a/Resources/Prototypes/_Ronstation/Maps/saltern-2.yml
+++ b/Resources/Prototypes/_Ronstation/Maps/saltern-2.yml
@@ -28,6 +28,7 @@
             Chef: [ 1, 2 ]
             Janitor: [ 1, 2 ]
             ServiceWorker: [ 2, 4 ]
+            Reporter: [ 1, 1 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
             AtmosphericTechnician: [ 2, 2 ]
@@ -45,7 +46,6 @@
             ResearchAssistant: [ 2, 4 ]
             Borg: [ 2, 2 ]
             Chaplain: [ 1, 1 ]
-            ForensicMantis: [ 1, 1 ]
             Librarian: [ 1, 1 ]
             #security
             HeadOfSecurity: [ 1, 1 ]


### PR DESCRIPTION

# Description

Fixes Saltern's job pool.
There is no Mantis spawn point, yet there mantis job slot in the job pool. There is a reporter spawn point, yet there is no reporter job slot in the job pool.

---

# TODO

- [x] Remove mantis role in job-pool prototype.
- [x] Add reporter role in job-pool prototype.

---

# Changelog

:cl:
- fix: Fixed saltern-2's map pool.