### PR TITLE
Shorten emergency shuttle docking time.

### DIFF
--- a/Resources/ConfigPresets/EinsteinEngines/default.toml
+++ b/Resources/ConfigPresets/EinsteinEngines/default.toml
@@ -60,6 +60,7 @@ map_enabled = true
 
 [shuttle]
 arrivals_map = "Maps/_Ronstation/Misc/terminal.yml"
+emergency_dock_time = 120f
 
 [glimmer]
 enabled = false

--- a/Resources/ConfigPresets/Ronstation/RonStation.toml
+++ b/Resources/ConfigPresets/Ronstation/RonStation.toml
@@ -58,6 +58,7 @@ map_enabled = true
 
 [shuttle]
 arrivals_map = "Maps/_Ronstation/Misc/terminal.yml"
+emergency_dock_time = 120f
 
 [glimmer]
 enabled = false


### PR DESCRIPTION
# Description

Shortened emergency shuttle docking time to wizden levels.

---

# Changelog

:cl:
- tweak: Emergency shuttle docking time has been reduced from 240 seconds (4 minutes) to 120 seconds (2 minutes).
