### PR TITLE
Made IPCs roundstart and disabled AnomalousPositronics trait.

### DIFF
--- a/Resources/Prototypes/Species/ipc.yml
+++ b/Resources/Prototypes/Species/ipc.yml
@@ -1,7 +1,7 @@
 - type: species
   id: IPC
   name: species-name-ipc
-  roundStart: false # Ronstation - Race rework.
+  roundStart: true
   prototype: MobIPC
   sprites: MobIPCSprites
   defaultSkinTone: "#aaa9ad"

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -332,8 +332,19 @@
         - type: PsionicInsulation
   requirements:
     - !type:CharacterSpeciesRequirement
+      inverted: true # Ronstaiton - Race rework.
       species:
         - IPC
+        - Shadowkin # Ronstaiton - Race rework.
+        - Gingerbread # Ronstaiton - Race rework.
+        - Vox # Ronstaiton - Race rework.
+        - Diona # Ronstaiton - Race rework.
+        - Dwarf # Ronstaiton - Race rework.
+        - SlimePerson # Ronstaiton - Race rework.
+        - Arachnid # Ronstaiton - Race rework.
+        - Reptilian # Ronstaiton - Race rework.
+        - Human # Ronstaiton - Race rework.
+        - Moth # Ronstaiton - Race rework.
 
 - type: trait
   id: AnimalFriend


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Description.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Screenshot from 2025-01-11 22-57-51](https://github.com/user-attachments/assets/b2362486-95a3-414c-ad5f-32a0343e3573)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added IPCs as roundstart race.
- remove: Anomalous Positronic trait is no longer acquireable.
