### PR TITLE
Make Nanotrasen Representative whitelisted.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -7,6 +7,7 @@
     - !type:DepartmentTimeRequirement
       department: Command
       min: 54000 # 15 hours
+    - !type:CharacterWhitelistRequirement # Ronstation- Whitelist requirement due to the role requiring advanced knowledge of actually roleplaying as a mere representative.
   weight: 20
   startingGear: NanotrasenRepresentativeGear
   icon: "JobIconNanotrasenRepresentative"
@@ -22,7 +23,7 @@
   - Maintenance
   - Engineering
   - Medical
-  - Research  
+  - Research
   - Command
   - NanotrasenRepresentative
   special:


### PR DESCRIPTION

# Description

Makes Nanotrasen Representative Whitelisted, due to it's role requiring someone to actually know how to roleplay as a representative that gives fax to command, including the captain.

---

<details><summary><h1>Media</h1></summary>
<p>

![Screenshot from 2025-01-14 14-14-55](https://github.com/user-attachments/assets/d48fa408-8d4c-434e-9c15-518ac933ad71)

</p>
</details>

---

# Changelog

:cl:
- tweak: Nanotrasen Representative is now whitelisted.
