### PR TITLE
Fix diagonal wall blending and renames windows, windoors, and chairs.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: Windoor
   parent: BaseWindoor
-  name: Windoor
+  name: Glass Windoor
   description: It's a window and a sliding door. Wow!
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -99,7 +99,7 @@
     anchored: true
 
 - type: entity
-  name: chair
+  name: steel chair
   id: Chair
   parent: ChairBase
   components:
@@ -110,7 +110,7 @@
     node: chair
 
 - type: entity
-  name: chair
+  name: steel chair
   id: ChairGreyscale
   parent: Chair
   suffix: White

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: Window
   parent: BaseStructure
-  name: window
+  name: glass window
   description: Don't smudge up the glass down there.
   placement:
     mode: SnapgridCenter
@@ -102,7 +102,7 @@
 - type: entity
   id: WindowDirectional
   parent: BaseStructure
-  name: directional window
+  name: directional glass window
   description: Don't smudge up the glass down there.
   placement:
     mode: SnapgridCenter
@@ -233,7 +233,7 @@
     state: state0
   - type: IconSmooth
     mode: Diagonal
-    key: walls
+    key: windows
     base: state
   - type: Icon
     sprite: _Ronstation/Structures/Windows/window_diagonal.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fixes diagonal wall blending.
Renames windows to "glass windows".
Renames windoors to "glass windoors".
Renames chairs to "steel chairs".
The last 3 are for easier search.

---

<details><summary><h1>Media</h1></summary>
<p>

![Screenshot from 2025-01-23 19-21-12](https://github.com/user-attachments/assets/ee128e26-7fbc-44c9-85ba-2293f5a3056e)
![Screenshot from 2025-01-23 19-21-31](https://github.com/user-attachments/assets/38055857-b027-4522-9d9f-e343affdb00f)
![Screenshot from 2025-01-23 19-20-59](https://github.com/user-attachments/assets/cdc64dbe-96af-44a3-9968-774d8a2c72ff)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Windows are renamed as "glass windows".
- tweak: Windoors are renamed as "glass windoors".
- tweak: Chairs are renamed as "steel chairs".
- fix: Fixed diagonal window not blending with the rest of the windows.
