### PR TITLE
Give brigmedic paramedic playtime requirements.

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -4,8 +4,8 @@
   description: job-description-brigmedic
   playTimeTracker: JobBrigmedic
   requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Medical
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobParamedic
       min: 21600 # 6 hrs
     - !type:CharacterDepartmentTimeRequirement
       department: Security


### PR DESCRIPTION
# Description

Considering how brigmedics have to go out of their way to save security officers during combat situations (pretty much how paramedics do towards other people), they should be given paramedic playtime requirements to make sure they don't become cowards who stay in their own rooms.

---

<details><summary><h1>Media</h1></summary>
<p>

![Screenshot from 2025-01-24 13-15-24](https://github.com/user-attachments/assets/5df03311-2a41-462d-bdb6-d927d3b75e84)

</p>
</details>

---

# Changelog

:cl:
- tweak: Replaced medical department playtime requirements with paramedic playtime requirements for brigmedic role.
