### PR TITLE
Make bedsheets eatable by moths.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -23,6 +23,17 @@
   - type: Tag
     tags:
     - Bedsheet
+    - ClothMade # Ronstation - Mothpeople should be able to eat these.
+  - type: Food # Ronstation - Mothpeople should be able to eat these.
+    requiresSpecialDigestion: true
+    delay: 2
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 10
 
 - type: entity
   id: BedsheetBlack


### PR DESCRIPTION
# Description

Moths and mothroaches should be able to eat bedsheets now for logic (and funny) reasons.

Imagine having to go to HoP because your mothroach ate your objective bedsheet.

Changes in this commit are licensed under MIT.

---

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

—-
# Changelog

:cl:
- add: Moths and mothroaches can now eat bedsheets.
