### PR TITLE
Magistrate whitelist.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/magistrate.yml
@@ -15,6 +15,7 @@
       traits:
         - Foreigner
         - ForeignerLight
+    - !type:CharacterWhitelistRequirement # Ronstation- Whitelist requirement due to being the same as chief justice.
   weight: 20
   startingGear: MagistrateGear
   icon: "JobIconMagistrate"


### PR DESCRIPTION

# Description

EE added the magistrate, but it's role is essentially the same as the chief justice role, so it needs a whitelist.

---

# Changelog

:cl:
- tweak: Magistrate is now whitelisted, due to the role being the name as the chief justice.
