### PR TITLE
Guidebook fix.

### DIFF
--- a/Resources/Prototypes/Guidebook/Lore/settinglore.yml
+++ b/Resources/Prototypes/Guidebook/Lore/settinglore.yml
@@ -1,66 +1,66 @@
-- type: guideEntry
-  id: SettingLore
-  name: guide-entry-setting-lore
-  text: "/ServerInfo/Guidebook/Lore/SettingLore.xml"
-  children:
-    - Corporations
+#- type: guideEntry
+#  id: SettingLore
+#  name: guide-entry-setting-lore
+#  text: "/ServerInfo/Guidebook/Lore/SettingLore.xml"
+#  children:
+#    - Corporations
 
-- type: guideEntry
-  id: Corporations
-  name: guide-entry-corporations
-  text: "/ServerInfo/Guidebook/Lore/Corporations/Corporations.xml"
-  children:
-    - IdrisIncorporated
-    - EinsteinEngines
-    - StellarCorporateConglomerate
-    - NanoTrasen
-    - OrionExpress
-    - ZengHuPharmaceuticals
-    - HephaestusIndustries
-    - ZavodskoiInterstellar
-    - PrivateMilitaryContractingGroup
+#- type: guideEntry
+#  id: Corporations
+#  name: guide-entry-corporations
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/Corporations.xml"
+#  children:
+#    - IdrisIncorporated
+#    - EinsteinEngines
+#    - StellarCorporateConglomerate
+#    - NanoTrasen
+#    - OrionExpress
+#    - ZengHuPharmaceuticals
+#    - HephaestusIndustries
+#    - ZavodskoiInterstellar
+#    - PrivateMilitaryContractingGroup
 
-- type: guideEntry
-  id: IdrisIncorporated
-  name: guide-entry-idris-incorporated
-  text: "/ServerInfo/Guidebook/Lore/Corporations/IdrisIncorporated.xml"
+#- type: guideEntry
+#  id: IdrisIncorporated
+#  name: guide-entry-idris-incorporated
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/IdrisIncorporated.xml"
 
-- type: guideEntry
-  id: EinsteinEngines
-  name: guide-entry-einstein-engines
-  text: "/ServerInfo/Guidebook/Lore/Corporations/EinsteinEngines.xml"
+#- type: guideEntry
+#  id: EinsteinEngines
+#  name: guide-entry-einstein-engines
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/EinsteinEngines.xml"
 
-- type: guideEntry
-  id: StellarCorporateConglomerate
-  name: guide-entry-stellar-corporate-conglomerate
-  text: "/ServerInfo/Guidebook/Lore/Corporations/StellarCorporateConglomerate.xml"
+#- type: guideEntry
+#  id: StellarCorporateConglomerate
+#  name: guide-entry-stellar-corporate-conglomerate
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/StellarCorporateConglomerate.xml"
 
-- type: guideEntry
-  id: NanoTrasen
-  name: guide-entry-nanotrasen
-  text: "/ServerInfo/Guidebook/Lore/Corporations/NanoTrasen.xml"
+#- type: guideEntry
+#  id: NanoTrasen
+#  name: guide-entry-nanotrasen
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/NanoTrasen.xml"
 
-- type: guideEntry
-  id: OrionExpress
-  name: guide-entry-orion-express
-  text: "/ServerInfo/Guidebook/Lore/Corporations/OrionExpress.xml"
+#- type: guideEntry
+#  id: OrionExpress
+#  name: guide-entry-orion-express
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/OrionExpress.xml"
 
-- type: guideEntry
-  id: ZengHuPharmaceuticals
-  name: guide-entry-zeng-hu-pharmaceuticals
-  text: "/ServerInfo/Guidebook/Lore/Corporations/ZengHuPharmaceuticals.xml"
+#- type: guideEntry
+#  id: ZengHuPharmaceuticals
+#  name: guide-entry-zeng-hu-pharmaceuticals
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/ZengHuPharmaceuticals.xml"
 
-- type: guideEntry
-  id: HephaestusIndustries
-  name: guide-entry-hephaestus-industries
-  text: "/ServerInfo/Guidebook/Lore/Corporations/HephaestusIndustries.xml"
+#- type: guideEntry
+#  id: HephaestusIndustries
+#  name: guide-entry-hephaestus-industries
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/HephaestusIndustries.xml"
 
-- type: guideEntry
-  id: ZavodskoiInterstellar
-  name: guide-entry-zavodskoi-interstellar
-  text: "/ServerInfo/Guidebook/Lore/Corporations/ZavodskoiInterstellar.xml"
+#- type: guideEntry
+#  id: ZavodskoiInterstellar
+#  name: guide-entry-zavodskoi-interstellar
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/ZavodskoiInterstellar.xml"
 
-- type: guideEntry
-  id: PrivateMilitaryContractingGroup
-  name: guide-entry-private-military-contracting-group
-  text: "/ServerInfo/Guidebook/Lore/Corporations/PrivateMilitaryContractingGroup.xml"
+#- type: guideEntry
+#  id: PrivateMilitaryContractingGroup
+#  name: guide-entry-private-military-contracting-group
+#  text: "/ServerInfo/Guidebook/Lore/Corporations/PrivateMilitaryContractingGroup.xml"

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -29,7 +29,6 @@
   name: guide-entry-chemist
   text: "/ServerInfo/Guidebook/Medical/Chemist.xml"
   children:
-  - Medicine
   - Botanicals
   - AdvancedBrute
 

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -10,7 +10,7 @@
   - Surgery
 
 - type: guideEntry
-  id: Medical Doctor
+  id: MedicalDoctor
   name: guide-entry-medicaldoctor
   text: "/ServerInfo/Guidebook/Medical/MedicalDoctor.xml"
 

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -3,7 +3,7 @@
   name: guide-entry-medical
   text: "/ServerInfo/Guidebook/Medical/Medical.xml"
   children:
-  - Medical Doctor
+  - MedicalDoctor
   - Chemist
   - Cloning
   - Cryogenics

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -3,14 +3,14 @@
   name: guide-entry-medical
   text: "/ServerInfo/Guidebook/Medical/Medical.xml"
   children:
-  - MedicalDoctor
+  - Medical Doctor
   - Chemist
   - Cloning
   - Cryogenics
   - Surgery
 
 - type: guideEntry
-  id: MedicalDoctor
+  id: Medical Doctor
   name: guide-entry-medicaldoctor
   text: "/ServerInfo/Guidebook/Medical/MedicalDoctor.xml"
 

--- a/Resources/Prototypes/Guidebook/psionics.yml
+++ b/Resources/Prototypes/Guidebook/psionics.yml
@@ -1,35 +1,35 @@
-- type: guideEntry
-  id: Psionics
-  name: guide-entry-psionics
-  text: "/ServerInfo/Guidebook/Psionics/Psionics.xml"
-  children:
-  - Glimmer
-  - PsionicInsulation
-  - Mindbreaking
-  - AltarsGolemancy
-  - GlimmerCreatures
+#- type: guideEntry
+#  id: Psionics
+#  name: guide-entry-psionics
+#  text: "/ServerInfo/Guidebook/Psionics/Psionics.xml"
+#  children:
+#  - Glimmer
+#  - PsionicInsulation
+#  - Mindbreaking
+#  - AltarsGolemancy
+#  - GlimmerCreatures
 
-- type: guideEntry
-  id: Glimmer
-  name: guide-entry-glimmer
-  text: "/ServerInfo/Guidebook/Psionics/Glimmer.xml"
+#- type: guideEntry
+#  id: Glimmer
+#  name: guide-entry-glimmer
+#  text: "/ServerInfo/Guidebook/Psionics/Glimmer.xml"
 
-- type: guideEntry
-  id: PsionicInsulation
-  name: guide-entry-psionic-insulation
-  text: "/ServerInfo/Guidebook/Psionics/PsionicInsulation.xml"
+#- type: guideEntry
+#  id: PsionicInsulation
+#  name: guide-entry-psionic-insulation
+#  text: "/ServerInfo/Guidebook/Psionics/PsionicInsulation.xml"
 
-- type: guideEntry
-  id: Mindbreaking
-  name: guide-entry-mindbreaking
-  text: "/ServerInfo/Guidebook/Psionics/Mindbreaking.xml"
+#- type: guideEntry
+#  id: Mindbreaking
+#  name: guide-entry-mindbreaking
+#  text: "/ServerInfo/Guidebook/Psionics/Mindbreaking.xml"
 
-- type: guideEntry
-  id: AltarsGolemancy
-  name: guide-entry-altars-golemancy
-  text: "/ServerInfo/Guidebook/Psionics/Altar.xml"
+#- type: guideEntry
+#  id: AltarsGolemancy
+#  name: guide-entry-altars-golemancy
+#  text: "/ServerInfo/Guidebook/Psionics/Altar.xml"
 
-- type: guideEntry
-  id: GlimmerCreatures
-  name: guide-entry-glimmer-creatures
-  text: "/ServerInfo/Guidebook/Psionics/GlimmerCreatures.xml"
+#- type: guideEntry
+#  id: GlimmerCreatures
+#  name: guide-entry-glimmer-creatures
+#  text: "/ServerInfo/Guidebook/Psionics/GlimmerCreatures.xml"

--- a/Resources/Prototypes/Guidebook/ss14.yml
+++ b/Resources/Prototypes/Guidebook/ss14.yml
@@ -13,8 +13,8 @@
   - Writing
   - Glossary
   - LoadoutInfo
-  - SettingLore
-  - Psionics
+  #- SettingLore # Ronstation - Lore removed, pending rework.
+  #- Psionics # Ronstation - Psionics does not exist.
 
 - type: guideEntry
   id: Writing


### PR DESCRIPTION
# Description

Removed psionics and lore guidebooks.
- Psionics no longer exists in Ronstation EE.
- Lore needs a rework.
Also fixes medical doctor guide.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Removed psionics guides, due to lack of psionics.
- remove: Removed lore guides, pending rework.
- fix: Fixed medical doctor guides.
