### PR TITLE
No ATS needed for atlas.

### DIFF
--- a/Resources/Prototypes/_Ronstation/Maps/atlas-b.yml
+++ b/Resources/Prototypes/_Ronstation/Maps/atlas-b.yml
@@ -6,7 +6,7 @@
   maxPlayers: 20
   stations:
     Atlas:
-      stationProto: StandardNanotrasenStation
+      stationProto: StandardNanotrasenStationNoATS
       components:
         - type: StationNameSetup
           mapNameTemplate: '{0} Atlas B {1}'


### PR DESCRIPTION

# Description

Since Atlas is it's own ATS, there seems to be no need for another ATS.

---

# Changelog

:cl:
- remove: Removed ATS on Atlas.
