### PR TITLE
Make weapons crates easier to break open

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -297,7 +297,7 @@
     access: [["Hydroponics"]]
 
 - type: entity
-  parent: CrateBaseSecureReinforced
+  parent: CrateBaseSecure
   id: CrateWeaponSecure
   name: secure weapon crate
   components:


### PR DESCRIPTION


# Description
Just like on old MIT/WizDen Ron.

Benefits salvagers who like upgrading their weaponry early instead of the boring ol' PKA. PKAs excel at breaking walls while the WT550 is meant to shoot goliaths.


(okay, let's be very honest that this only benefits one person with a specific playstyle.)

---

# Changelog

:cl: Lemuria
- tweak: Made weapons crates easier to break open.
