### PR TITLE
Restricted bionic arm trait to security only.

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -523,29 +523,29 @@
           entityProduced: MaterialWebSilk1
           hungerCost: 4
 
-- type: trait
-  id: BionicArm
-  category: Physical
-  points: -8
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-        - Gladiator
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: Prying
-          speedModifier: 1
-          pryPowered: true
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-bionic-arm-message
-          fontSize: 12
-          requireDetailRange: true
+#- type: trait
+#  id: BionicArm
+#  category: Physical
+#  points: -8
+#  requirements:
+#    - !type:CharacterJobRequirement
+#      inverted: true
+#      jobs:
+#        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+#        - Gladiator
+#    - !type:CharacterItemGroupRequirement
+#      group: TraitsMind
+#  functions:
+#    - !type:TraitAddComponent
+#      components:
+#        - type: Prying
+#          speedModifier: 1
+#          pryPowered: true
+#    - !type:TraitPushDescription
+#      descriptionExtensions:
+#        - description: examine-bionic-arm-message
+#          fontSize: 12
+#          requireDetailRange: true
 
 - type: trait
   id: PlateletFactories

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -523,29 +523,29 @@
           entityProduced: MaterialWebSilk1
           hungerCost: 4
 
-#- type: trait
-#  id: BionicArm
-#  category: Physical
-#  points: -8
-#  requirements:
-#    - !type:CharacterJobRequirement
-#      inverted: true
-#      jobs:
-#        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-#        - Gladiator
-#    - !type:CharacterItemGroupRequirement
-#      group: TraitsMind
-#  functions:
-#    - !type:TraitAddComponent
-#      components:
-#        - type: Prying
-#          speedModifier: 1
-#          pryPowered: true
-#    - !type:TraitPushDescription
-#      descriptionExtensions:
-#        - description: examine-bionic-arm-message
-#          fontSize: 12
-#          requireDetailRange: true
+- type: trait
+  id: BionicArm
+  category: Physical
+  points: -8
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Prying
+          speedModifier: 1
+          pryPowered: true
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-arm-message
+          fontSize: 12
+          requireDetailRange: true
 
 - type: trait
   id: PlateletFactories
@@ -685,6 +685,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
@@ -695,6 +696,9 @@
         - CyberEyesOmni
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -699,6 +699,9 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
+    - !type:CharacterJobRequirement
+      jobs:
+        - Captain
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -535,12 +535,17 @@
         - Gladiator
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
     - !type:CharacterJobRequirement
       jobs:
         - Captain
+        - BlueshieldOfficer
+        - HeadOfSecurity
+        - Warden
+        - Brigmedic
+        - Detective
+        - SeniorOfficer
+        - SecurityOfficer
+        - SecurityCadet
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -535,6 +535,12 @@
         - Gladiator
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+    - !type:CharacterJobRequirement
+      jobs:
+        - Captain
   functions:
     - !type:TraitAddComponent
       components:
@@ -685,7 +691,6 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-        - Gladiator
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
@@ -696,12 +701,6 @@
         - CyberEyesOmni
     - !type:CharacterItemGroupRequirement
       group: TraitsMind
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
# Description

Restricted bionic arm trait to security and captain only.

---

# Changelog

:cl:
- tweak: Bionic arm trait has been restricted to security personnel and captain only.