### PR TITLE
Enable autoeat and autodrink.

### DIFF
--- a/Resources/ConfigPresets/EinsteinEngines/default.toml
+++ b/Resources/ConfigPresets/EinsteinEngines/default.toml
@@ -15,6 +15,8 @@ desc               = "An alternative upstream that favors content intended for R
 soft_max_players   = 60
 lobbyenabled       = true
 lobbyduration      = 240
+auto_eat_food      = true # Ronstation
+auto_eat_drinks    = true # Ronstation
 
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:med"

--- a/Resources/ConfigPresets/Ronstation/RonStation.toml
+++ b/Resources/ConfigPresets/Ronstation/RonStation.toml
@@ -17,6 +17,8 @@ lobbyenabled       = true
 lobbyduration      = 240
 station_goals      = false
 map_pool           = "RonstationMapPool"
+auto_eat_food      = true
+auto_eat_drinks    = true
 
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:low"


### PR DESCRIPTION

# Description

Enables autoeating and autodrinking, through configuration modification.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

---

# Changelog

:cl:
- tweak: You no longer have to click everytime you eat or drink.
