### PR TITLE
Update translators

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -38,7 +38,7 @@
   components:
   - type: ItemToggle
   - type: PowerCellDraw
-    drawRate: 1
+    drawRate: 0.3
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
Buffs translators so they do not die extremely fast, they will still die quite fast and thats intended for taking the trait but they should last longer than 2 minutes or so at least, plus they already take up a pocket or a 2x2 slot space so there is already enough trade off for the 2 or 4 points depending if you took the minor or major ver of that trait.