### PR TITLE
Update alert evac times.

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -14,17 +14,19 @@
       color: DodgerBlue
       forceEnableEmergencyLights: true
       emergencyLightColor: DodgerBlue
-      shuttleTime: 600
+      shuttleTime: 500
     violet:
       announcement: alert-level-violet-announcement
       sound: /Audio/Announcements/Alerts/code_violet.ogg
       color: Violet
       emergencyLightColor: Violet
       forceEnableEmergencyLights: true
-      shuttleTime: 600
+      shuttleTime: 900
     white:
       announcement: alert-level-white-announcement
+      selectable: false
       sound: /Audio/Announcements/Alerts/code_white.ogg
+      disableSelection: true
       emergencyLightColor: "#F6CCF6"
       color: White
       shuttleTime: 600
@@ -34,14 +36,14 @@
       color: Yellow
       emergencyLightColor: Goldenrod
       forceEnableEmergencyLights: true
-      shuttleTime: 600
+      shuttleTime: 400
     red:
       announcement: alert-level-red-announcement
       sound: /Audio/Announcements/Alerts/code_red.ogg
       color: Red
       emergencyLightColor: Red
       forceEnableEmergencyLights: true
-      shuttleTime: 600
+      shuttleTime: 300
     gamma:
       announcement: alert-level-gamma-announcement
       selectable: false
@@ -50,7 +52,7 @@
       color: PaleVioletRed
       emergencyLightColor: PaleVioletRed
       forceEnableEmergencyLights: true
-      shuttleTime: 600
+      shuttleTime: 250
     delta:
       announcement: alert-level-delta-announcement
       selectable: false
@@ -68,4 +70,4 @@
       color: DarkViolet
       emergencyLightColor: DarkViolet
       forceEnableEmergencyLights: true
-      shuttleTime: 1200
+      shuttleTime: 4600


### PR DESCRIPTION
Updates alert levels evac timers to be more fitting and disables code white selecting due to the fact Psionics are disabled.

Code blue time from 600 to 500, this makes evac take less time than code green would as its more urgent.

Code violet time from 600 to 900, this is due to the fact violet infers some sort of highly dangerous virus that must be contained.

Code yellow time from 600 to 400, the station is severely damaged and is no longer safe for station crew as such faster evac.

Code red time from 600 to 300, the station has an extremly urgent threat to the point they must leave the station imminently.

Code gamma time from 600 to 250, the station is under a threat that it is completely unsafe for the health of employees.

Code epsilon time from 1200 to 4600, all contracts are to be terminated and no trespassers must avoid being "fired".