### PR TITLE
Rename Mantis to Ward Mantis.

### DIFF
--- a/Resources/Locale/en-US/loadouts/categories.ftl
+++ b/Resources/Locale/en-US/loadouts/categories.ftl
@@ -41,7 +41,7 @@ loadout-category-JobsEpistemicsGolemancer = Roboticist
 loadout-category-JobsEpistemicsMystagogue = Research Director
 loadout-category-JobsEpistemicsMystic = Senior Scientist
 loadout-category-JobsEpistemicsNoviciate = Research Assistant
-loadout-category-JobsEpistemicsPsionicMantis = Mantis
+loadout-category-JobsEpistemicsPsionicMantis = Ward Mantis
 
 # Logistics
 loadout-category-JobsLogistics = Logistics

--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -308,20 +308,20 @@ character-item-group-LoadoutNoviciateOuter = Research Assistant Outerwear
 character-item-group-LoadoutNoviciateShoes = Research Assistant Shoes
 character-item-group-LoadoutNoviciateUniforms = Research Assistant Uniforms
 
-# Science - Mantis
-character-item-group-LoadoutPsionicMantisBackpacks = Mantis Backpacks
-character-item-group-LoadoutPsionicMantisBelt = Mantis Belt
-character-item-group-LoadoutPsionicMantisEars = Mantis Ears
-character-item-group-LoadoutPsionicMantisEquipment = Mantis Equipment
-character-item-group-LoadoutPsionicMantisEyes = Mantis Eyewear
-character-item-group-LoadoutPsionicMantisGloves = Mantis Gloves
-character-item-group-LoadoutPsionicMantisHead = Mantis Headgear
-character-item-group-LoadoutPsionicMantisId = Mantis Id
-character-item-group-LoadoutPsionicMantisNeck = Mantis Neckwear
-character-item-group-LoadoutPsionicMantisMask = Mantis Masks
-character-item-group-LoadoutPsionicMantisOuter = Mantis Outerwear
-character-item-group-LoadoutPsionicMantisShoes = Mantis Shoes
-character-item-group-LoadoutPsionicMantisUniforms = Mantis Uniforms
+# Science - Ward Mantis
+character-item-group-LoadoutPsionicMantisBackpacks = Ward Mantis Backpacks
+character-item-group-LoadoutPsionicMantisBelt = Ward Mantis Belt
+character-item-group-LoadoutPsionicMantisEars = Ward Mantis Ears
+character-item-group-LoadoutPsionicMantisEquipment = Ward Mantis Equipment
+character-item-group-LoadoutPsionicMantisEyes = Ward Mantis Eyewear
+character-item-group-LoadoutPsionicMantisGloves = Ward Mantis Gloves
+character-item-group-LoadoutPsionicMantisHead = Ward Mantis Headgear
+character-item-group-LoadoutPsionicMantisId = Ward Mantis Id
+character-item-group-LoadoutPsionicMantisNeck = Ward Mantis Neckwear
+character-item-group-LoadoutPsionicMantisMask = Ward Mantis Masks
+character-item-group-LoadoutPsionicMantisOuter = Ward Mantis Outerwear
+character-item-group-LoadoutPsionicMantisShoes = Ward Mantis Shoes
+character-item-group-LoadoutPsionicMantisUniforms = Ward Mantis Uniforms
 
 # Cargo
 character-item-group-LoadoutLogisticsBackpacks = Cargo Backpacks

--- a/Resources/Locale/en-US/nyanotrasen/job/job-names.ftl
+++ b/Resources/Locale/en-US/nyanotrasen/job/job-names.ftl
@@ -2,8 +2,8 @@ job-name-gladiator = Gladiator
 job-name-guard = Prison Guard
 job-name-mail-carrier = Mail Carrier
 job-name-martialartist =  Martial Artist
-job-name-mantis = Mantis
+job-name-mantis = Ward Mantis
 
 # Role timers
 JobMailCarrier = Mail Carrier
-JobForensicMantis = Mantis
+JobForensicMantis = Ward Mantis

--- a/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Airlocks/access.yml
@@ -11,7 +11,7 @@
 - type: entity
   parent: AirlockScience
   id: AirlockMantisLocked
-  suffix: Mantis, Locked
+  suffix: Ward Mantis, Locked # Ronstation - 'Mantis' has been renamed to 'Ward Mantis.'.
   components:
   - type: ContainerFill
     containers:
@@ -21,7 +21,7 @@
 - type: entity
   parent: AirlockScienceGlass
   id: AirlockMantisGlassLocked
-  suffix: Mantis, Locked
+  suffix: Ward Mantis, Locked # Ronstation - 'Mantis' has been renamed to 'Ward Mantis.'.
   components:
   - type: ContainerFill
     containers:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/jobs.yml
@@ -65,7 +65,7 @@
 - type: entity
   id: SpawnPointForensicMantis
   parent: SpawnPointJobBase
-  name: mantis
+  name: Ward Mantis
   components:
   - type: SpawnPoint
     job_id: ForensicMantis


### PR DESCRIPTION

# Description

Renamed "Mantis" to "Ward Mantis" to prevent confusion of the role between Ronstation and other EE forks.

The role of Mantis has been reworked enough to become so different, a new name is required.

---

# Changelog

:cl:
- tweak: Renamed 'Mantis' to 'Ward Mantis'.
