### PR TITLE
Disable arrivals, pending rework.

### DIFF
--- a/Resources/ConfigPresets/EinsteinEngines/default.toml
+++ b/Resources/ConfigPresets/EinsteinEngines/default.toml
@@ -60,6 +60,7 @@ map_enabled = true
 #Required for development without glimmer, and psionics.
 
 [shuttle]
+arrivals = false # Ronstation = pending rework, due to numerous bugs.
 arrivals_map = "Maps/_Ronstation/Misc/terminal.yml"
 emergency_dock_time = 120
 

--- a/Resources/ConfigPresets/Ronstation/RonStation.toml
+++ b/Resources/ConfigPresets/Ronstation/RonStation.toml
@@ -59,6 +59,7 @@ map_enabled = true
 #enabled = true
 
 [shuttle]
+arrivals = false # Ronstation = pending rework, due to numerous bugs.
 arrivals_map = "Maps/_Ronstation/Misc/terminal.yml"
 emergency_dock_time = 120
 


### PR DESCRIPTION
# Description

Sometimes arrivals shuttle won't dock to terminal, causing players to get stranded in the terminal. It's tiring and so game-breaking, and we lack other solutions.

---

# TODO

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Disabled arrivals, pending rework.
